### PR TITLE
feat: add GET /stats endpoint

### DIFF
--- a/relayer/index.js
+++ b/relayer/index.js
@@ -342,6 +342,38 @@ app.get("/status/:id", async (req, res) => {
   }
 });
 
+// GET /stats — aggregate bounty statistics
+app.get("/stats", async (req, res) => {
+  try {
+    const count = await publicClient.readContract({
+      address: ESCROW_CONTRACT_ADDRESS,
+      abi: ESCROW_ABI,
+      functionName: "bountyCount",
+    });
+
+    const stats = { total: 0, open: 0, submitted: 0, approved: 0, rejected: 0, totalValueLocked: BigInt(0) };
+
+    for (let i = 0; i < Number(count); i++) {
+      const b = await publicClient.readContract({
+        address: ESCROW_CONTRACT_ADDRESS,
+        abi: ESCROW_ABI,
+        functionName: "bounties",
+        args: [BigInt(i)],
+      });
+      stats.total++;
+      const statusName = ["open", "submitted", "approved", "rejected"][Number(b[6])];
+      stats[statusName]++;
+      if (statusName === "open" || statusName === "submitted") {
+        stats.totalValueLocked += BigInt(b[4]);
+      }
+    }
+
+    res.json({ ...stats, totalValueLocked: stats.totalValueLocked.toString() });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // GET /health — enhanced with uptime and connectivity checks
 const startTime = Date.now();
 


### PR DESCRIPTION
## Summary
Closes #7

Adds `GET /stats` endpoint to the relayer API returning aggregate bounty statistics.

## Changes
- New endpoint `GET /stats` in `relayer/index.js`
- Returns: `total`, `open`, `submitted`, `approved`, `rejected`, `totalValueLocked`
- `totalValueLocked` sums amounts for Open + Submitted bounties only
- Returns 500 with error message on RPC failure

## Test
```bash
curl http://localhost:3100/stats
# {"total":15,"open":2,"submitted":0,"approved":9,"rejected":4,"totalValueLocked":"10500000000"}
```