### PR TITLE
feat: add GET /stats endpoint to relayer

### DIFF
--- a/relayer/index.js
+++ b/relayer/index.js
@@ -272,6 +272,63 @@ app.get("/bounties", async (req, res) => {
   }
 });
 
+// GET /stats — aggregate bounty statistics
+app.get("/stats", async (req, res) => {
+  try {
+    const count = await publicClient.readContract({
+      address: ESCROW_CONTRACT_ADDRESS,
+      abi: ESCROW_ABI,
+      functionName: "bountyCount",
+    });
+
+    const stats = {
+      total: Number(count),
+      open: 0,
+      submitted: 0,
+      approved: 0,
+      rejected: 0,
+      totalValueLocked: "0",
+    };
+
+    let tvl = 0n;
+    const statusNames = ["Open", "Submitted", "Approved", "Rejected"];
+
+    for (let i = 0; i < Number(count); i++) {
+      const b = await publicClient.readContract({
+        address: ESCROW_CONTRACT_ADDRESS,
+        abi: ESCROW_ABI,
+        functionName: "bounties",
+        args: [BigInt(i)],
+      });
+      const statusCode = Number(b[6]);
+      const statusName = statusNames[statusCode];
+      const amount = b[4];
+
+      switch (statusName) {
+        case "Open":
+          stats.open++;
+          tvl += amount;
+          break;
+        case "Submitted":
+          stats.submitted++;
+          tvl += amount;
+          break;
+        case "Approved":
+          stats.approved++;
+          break;
+        case "Rejected":
+          stats.rejected++;
+          break;
+      }
+    }
+
+    stats.totalValueLocked = tvl.toString();
+    res.json(stats);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // GET /status/:id — detailed bounty status with GenLayer verdict
 app.get("/status/:id", async (req, res) => {
   try {
@@ -376,8 +433,9 @@ if (process.env.NODE_ENV !== "test") {
     console.log(`API listening on http://localhost:${PORT}`);
     console.log(`\nEndpoints:`);
     console.log(`  POST /submit      — { bountyId, prURL, solverAddress }`);
-    console.log(`  GET  /bounties    — list all bounties`);
-    console.log(`  GET  /status/:id  — bounty detail + GenLayer verdict`);
+    console.log(`  GET  /bounties       — list all bounties`);
+    console.log(`  GET  /stats          — aggregate bounty statistics`);
+    console.log(`  GET  /status/:id     — bounty detail + GenLayer verdict`);
     console.log(`  GET  /health      — check status\n`);
   });
 

--- a/relayer/index.test.js
+++ b/relayer/index.test.js
@@ -167,6 +167,84 @@ describe("GET /bounties", () => {
   });
 });
 
+// ─── GET /stats ────────────────────────────────────────────────────────────────
+
+describe("GET /stats", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns zeroed stats when no bounties exist", async () => {
+    mockPublicClient.readContract.mockResolvedValueOnce(BigInt(0));
+
+    const res = await request(app).get("/stats");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      total: 0,
+      open: 0,
+      submitted: 0,
+      approved: 0,
+      rejected: 0,
+      totalValueLocked: "0",
+    });
+  });
+
+  it("returns correct counts for mixed statuses", async () => {
+    const openBounty = [...BOUNTY_TUPLE]; // status 0 = Open
+    const submittedBounty = [...BOUNTY_TUPLE];
+    submittedBounty[0] = BigInt(1);
+    submittedBounty[6] = 1; // Submitted
+    const approvedBounty = [...BOUNTY_TUPLE];
+    approvedBounty[0] = BigInt(2);
+    approvedBounty[6] = 2; // Approved
+    const rejectedBounty = [...BOUNTY_TUPLE];
+    rejectedBounty[0] = BigInt(3);
+    rejectedBounty[6] = 3; // Rejected
+
+    mockPublicClient.readContract
+      .mockResolvedValueOnce(BigInt(4)) // bountyCount
+      .mockResolvedValueOnce(openBounty)
+      .mockResolvedValueOnce(submittedBounty)
+      .mockResolvedValueOnce(approvedBounty)
+      .mockResolvedValueOnce(rejectedBounty);
+
+    const res = await request(app).get("/stats");
+
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBe(4);
+    expect(res.body.open).toBe(1);
+    expect(res.body.submitted).toBe(1);
+    expect(res.body.approved).toBe(1);
+    expect(res.body.rejected).toBe(1);
+  });
+
+  it("calculates totalValueLocked from Open + Submitted only", async () => {
+    const openBounty = [...BOUNTY_TUPLE]; // amount = 500e6
+    const approvedBounty = [...BOUNTY_TUPLE];
+    approvedBounty[0] = BigInt(1);
+    approvedBounty[4] = BigInt(300e6);
+    approvedBounty[6] = 2; // Approved
+
+    mockPublicClient.readContract
+      .mockResolvedValueOnce(BigInt(2))
+      .mockResolvedValueOnce(openBounty)
+      .mockResolvedValueOnce(approvedBounty);
+
+    const res = await request(app).get("/stats");
+
+    expect(res.status).toBe(200);
+    expect(res.body.totalValueLocked).toBe("500000000"); // only Open bounty amount
+  });
+
+  it("returns 500 on RPC error", async () => {
+    mockPublicClient.readContract.mockRejectedValue(new Error("RPC down"));
+
+    const res = await request(app).get("/stats");
+
+    expect(res.status).toBe(500);
+    expect(res.body).toHaveProperty("error");
+  });
+});
+
 // ─── GET /status/:id ──────────────────────────────────────────────────────────
 
 describe("GET /status/:id", () => {


### PR DESCRIPTION
Closes #7

Implements `GET /stats` endpoint that returns aggregate bounty statistics:

- `total`: total number of bounties
- `open`: count of Open bounties
- `submitted`: count of Submitted bounties
- `approved`: count of Approved bounties
- `rejected`: count of Rejected bounties
- `totalValueLocked`: sum of amounts for Open + Submitted bounties (as string)

Returns 500 with error message on RPC failure.

Includes 4 unit tests covering:
- Empty state (zero bounties)
- Mixed statuses (correct counting)
- TVL calculation (only Open + Submitted)
- RPC error handling