### PR TITLE
feat: add input validation for createBounty form

### DIFF
--- a/relayer/index.js
+++ b/relayer/index.js
@@ -103,6 +103,52 @@ async function readGenLayerView(functionName) {
   }
 }
 
+// --- GitHub issue validation ---
+
+function parseGithubIssueUrl(url) {
+  const match = url.match(/^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)$/);
+  if (!match) return null;
+  return { owner: match[1], repo: match[2], issueNumber: parseInt(match[3], 10) };
+}
+
+async function validateGithubIssue(url) {
+  const parsed = parseGithubIssueUrl(url);
+  if (!parsed) {
+    return { valid: false, error: "Invalid GitHub issue URL format. Expected: https://github.com/owner/repo/issues/123" };
+  }
+
+  const { owner, repo, issueNumber } = parsed;
+
+  try {
+    const response = await fetch(`https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}`, {
+      headers: { "Accept": "application/vnd.github.v3+json" },
+      signal: AbortSignal.timeout(5000),
+    });
+
+    if (response.status === 404) {
+      return { valid: false, error: `Issue #${issueNumber} not found in ${owner}/${repo}` };
+    }
+
+    if (!response.ok) {
+      return { valid: false, error: `GitHub API error: ${response.status}` };
+    }
+
+    const issue = await response.json();
+
+    if (issue.pull_request) {
+      return { valid: false, error: "URL points to a pull request, not an issue" };
+    }
+
+    if (issue.state !== "open") {
+      return { valid: false, error: `Issue is ${issue.state}, only open issues can have bounties` };
+    }
+
+    return { valid: true, issue: { title: issue.title, state: issue.state, owner, repo, issueNumber } };
+  } catch (err) {
+    return { valid: false, error: `Failed to validate issue: ${err.message}` };
+  }
+}
+
 // --- Core flow ---
 
 async function handlePRSubmission(bountyId, prURL, solverAddress) {
@@ -325,6 +371,16 @@ app.get("/status/:id", async (req, res) => {
   }
 });
 
+// POST /validate-issue — validate a GitHub issue URL
+app.post("/validate-issue", async (req, res) => {
+  const { issueUrl } = req.body;
+  if (!issueUrl) {
+    return res.status(400).json({ valid: false, error: "Missing issueUrl" });
+  }
+  const result = await validateGithubIssue(issueUrl);
+  res.json(result);
+});
+
 // GET /health — enhanced with uptime and connectivity checks
 const startTime = Date.now();
 
@@ -362,7 +418,7 @@ app.get("/health", async (req, res) => {
 
 // --- Exports ---
 
-export { app, rateLimitMap };
+export { app, rateLimitMap, parseGithubIssueUrl, validateGithubIssue };
 
 // --- Start ---
 
@@ -375,10 +431,11 @@ if (process.env.NODE_ENV !== "test") {
   const server = app.listen(PORT, () => {
     console.log(`API listening on http://localhost:${PORT}`);
     console.log(`\nEndpoints:`);
-    console.log(`  POST /submit      — { bountyId, prURL, solverAddress }`);
-    console.log(`  GET  /bounties    — list all bounties`);
-    console.log(`  GET  /status/:id  — bounty detail + GenLayer verdict`);
-    console.log(`  GET  /health      — check status\n`);
+    console.log(`  POST /submit         — { bountyId, prURL, solverAddress }`);
+    console.log(`  POST /validate-issue — validate GitHub issue URL`);
+    console.log(`  GET  /bounties       — list all bounties`);
+    console.log(`  GET  /status/:id     — bounty detail + GenLayer verdict`);
+    console.log(`  GET  /health         — check status\n`);
   });
 
   server.on("error", (err) => {

--- a/relayer/index.test.js
+++ b/relayer/index.test.js
@@ -34,7 +34,7 @@ vi.mock("viem/chains", () => ({ avalancheFuji: {}, foundry: {} }));
 vi.mock("genlayer-js", () => ({ createClient: () => mockGlClient }));
 vi.mock("genlayer-js/chains", () => ({ localnet: {}, testnetBradbury: {} }));
 
-import { app, rateLimitMap } from "./index.js";
+import { app, rateLimitMap, parseGithubIssueUrl } from "./index.js";
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -416,5 +416,144 @@ describe("rate limiting on POST /submit", () => {
     expect(res.status).toBe(429);
     expect(res.headers["retry-after"]).toBeDefined();
     expect(Number(res.headers["retry-after"])).toBeGreaterThan(0);
+  });
+});
+
+// ─── parseGithubIssueUrl ─────────────────────────────────────────────────────
+
+describe("parseGithubIssueUrl", () => {
+  it("parses a valid GitHub issue URL", () => {
+    const result = parseGithubIssueUrl("https://github.com/owner/repo/issues/123");
+    expect(result).toEqual({ owner: "owner", repo: "repo", issueNumber: 123 });
+  });
+
+  it("returns null for invalid URL format", () => {
+    expect(parseGithubIssueUrl("https://github.com/owner/repo")).toBeNull();
+    expect(parseGithubIssueUrl("https://github.com/owner/repo/pull/123")).toBeNull();
+    expect(parseGithubIssueUrl("not-a-url")).toBeNull();
+    expect(parseGithubIssueUrl("")).toBeNull();
+  });
+
+  it("handles http URLs", () => {
+    const result = parseGithubIssueUrl("http://github.com/owner/repo/issues/456");
+    expect(result).toEqual({ owner: "owner", repo: "repo", issueNumber: 456 });
+  });
+
+  it("returns null for URLs with trailing slash", () => {
+    expect(parseGithubIssueUrl("https://github.com/owner/repo/issues/123/")).toBeNull();
+  });
+});
+
+// ─── POST /validate-issue ────────────────────────────────────────────────────
+
+describe("POST /validate-issue", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 when issueUrl is missing", async () => {
+    const res = await request(app).post("/validate-issue").send({});
+    expect(res.status).toBe(400);
+    expect(res.body.valid).toBe(false);
+    expect(res.body.error).toMatch(/missing/i);
+  });
+
+  it("returns invalid for malformed URL", async () => {
+    const res = await request(app)
+      .post("/validate-issue")
+      .send({ issueUrl: "not-a-url" });
+    expect(res.status).toBe(200);
+    expect(res.body.valid).toBe(false);
+    expect(res.body.error).toMatch(/invalid.*format/i);
+  });
+
+  it("returns valid: true for open issue", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ title: "Fix bug", state: "open", pull_request: undefined }),
+    }));
+
+    const res = await request(app)
+      .post("/validate-issue")
+      .send({ issueUrl: "https://github.com/owner/repo/issues/1" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.valid).toBe(true);
+    expect(res.body.issue.title).toBe("Fix bug");
+  });
+
+  it("returns invalid for closed issue", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ title: "Closed issue", state: "closed", pull_request: undefined }),
+    }));
+
+    const res = await request(app)
+      .post("/validate-issue")
+      .send({ issueUrl: "https://github.com/owner/repo/issues/1" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.valid).toBe(false);
+    expect(res.body.error).toMatch(/closed/i);
+  });
+
+  it("returns invalid for non-existent issue (404)", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+    }));
+
+    const res = await request(app)
+      .post("/validate-issue")
+      .send({ issueUrl: "https://github.com/owner/repo/issues/999" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.valid).toBe(false);
+    expect(res.body.error).toMatch(/not found/i);
+  });
+
+  it("returns invalid when URL points to a pull request", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ title: "My PR", state: "open", pull_request: { url: "..." } }),
+    }));
+
+    const res = await request(app)
+      .post("/validate-issue")
+      .send({ issueUrl: "https://github.com/owner/repo/issues/1" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.valid).toBe(false);
+    expect(res.body.error).toMatch(/pull request/i);
+  });
+
+  it("handles GitHub API errors gracefully", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    }));
+
+    const res = await request(app)
+      .post("/validate-issue")
+      .send({ issueUrl: "https://github.com/owner/repo/issues/1" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.valid).toBe(false);
+    expect(res.body.error).toMatch(/api error/i);
+  });
+
+  it("handles network errors gracefully", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("Network error")));
+
+    const res = await request(app)
+      .post("/validate-issue")
+      .send({ issueUrl: "https://github.com/owner/repo/issues/1" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.valid).toBe(false);
+    expect(res.body.error).toMatch(/failed to validate/i);
   });
 });


### PR DESCRIPTION
Closes #11

## Changes
- Added `POST /validate-issue` endpoint that validates GitHub issue URLs via GitHub API
- Added `parseGithubIssueUrl()` helper for URL parsing
- Validates: URL format, issue existence (404), issue is open, not a PR
- Frontend already has validation integration from previous work
- Added 12 new tests (39 total passing)

## Acceptance Criteria Met
- ✅ Relayer validates the issue URL hits a real GitHub issue (HTTP 200)
- ✅ Returns a clear error if the issue doesn't exist
- ✅ Frontend shows the error to the user